### PR TITLE
Add @dynamic property for UIActivityIndicatorView that solves memory lea...

### DIFF
--- a/UIImageView+UIActivityIndicatorForSDWebImage.m
+++ b/UIImageView+UIActivityIndicatorForSDWebImage.m
@@ -7,6 +7,9 @@
 //
 
 #import "UIImageView+UIActivityIndicatorForSDWebImage.h"
+#import <objc/runtime.h>
+
+static char STRING_KEY;
 
 #define TAG_ACTIVITY_INDICATOR 149462
 
@@ -17,36 +20,44 @@
 
 @end
 
-
 @implementation UIImageView (UIActivityIndicatorForSDWebImage)
+
+@dynamic activityIndicator;
+
+- (UIActivityIndicatorView *)activityIndicator {
+    return (UIActivityIndicatorView *)objc_getAssociatedObject(self, &STRING_KEY);
+}
+
+- (void)setActivityIndicator:(UIActivityIndicatorView *)activityIndicator {
+    objc_setAssociatedObject(self, &STRING_KEY, activityIndicator, OBJC_ASSOCIATION_RETAIN);
+}
 
 -(void) createActivityIndicatorWithStyle:(UIActivityIndicatorViewStyle) activityStyle {
     
-    UIActivityIndicatorView *activityIndicator = (UIActivityIndicatorView *)[self viewWithTag:TAG_ACTIVITY_INDICATOR];
-    if (activityIndicator == nil) {
-        activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:activityStyle];
+    if ([self activityIndicator] == nil) {
+        self.activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:activityStyle];
         
         //calculate the correct position
-        float width = activityIndicator.frame.size.width;
-        float height = activityIndicator.frame.size.height;
+        float width = self.activityIndicator.frame.size.width;
+        float height = self.activityIndicator.frame.size.height;
         float x = (self.frame.size.width / 2.0) - width/2;
         float y = (self.frame.size.height / 2.0) - height/2;
-        activityIndicator.frame = CGRectMake(x, y, width, height);
+        self.activityIndicator.frame = CGRectMake(x, y, width, height);
         
-        activityIndicator.hidesWhenStopped = YES;
-        activityIndicator.tag = TAG_ACTIVITY_INDICATOR;
-        [self addSubview:activityIndicator];
+        self.activityIndicator.hidesWhenStopped = YES;
+        self.activityIndicator.tag = TAG_ACTIVITY_INDICATOR;
+        [self addSubview:self.activityIndicator];
     }
     
-    [activityIndicator startAnimating];
+    [self.activityIndicator startAnimating];
     
 }
 
 -(void) removeActivityIndicator {
     
-    UIActivityIndicatorView *activityIndicator = (UIActivityIndicatorView *)[self viewWithTag:TAG_ACTIVITY_INDICATOR];
-    if (activityIndicator) {
-        [activityIndicator removeFromSuperview];
+    //    self.activityIndicator = (UIActivityIndicatorView *)[self viewWithTag:TAG_ACTIVITY_INDICATOR];
+    if ([self activityIndicator]) {
+        [[self activityIndicator] removeFromSuperview];
     }
     
 }
@@ -65,7 +76,7 @@
                     [weakSelf removeActivityIndicator];
                 }
      ];
-
+    
 }
 
 -(void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStye {
@@ -83,7 +94,7 @@
 }
 
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle{
-
+    
     [self createActivityIndicatorWithStyle:activityStyle];
     
     __weak typeof(self) weakSelf = self;
@@ -94,11 +105,11 @@
                     [weakSelf removeActivityIndicator];
                 }
      ];
-
+    
 }
 
 - (void)setImageWithURL:(NSURL *)url completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
-
+    
     [self createActivityIndicatorWithStyle:activityStyle];
     
     __weak typeof(self) weakSelf = self;
@@ -112,7 +123,7 @@
 }
 
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
-
+    
     [self createActivityIndicatorWithStyle:activityStyle];
     
     __weak typeof(self) weakSelf = self;
@@ -123,11 +134,11 @@
                     [weakSelf removeActivityIndicator];
                 }
      ];
-
+    
 }
 
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
-
+    
     [self createActivityIndicatorWithStyle:activityStyle];
     
     __weak typeof(self) weakSelf = self;
@@ -139,11 +150,11 @@
                     [weakSelf removeActivityIndicator];
                 }
      ];
-
+    
 }
 
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
-
+    
     [self createActivityIndicatorWithStyle:activityStyle];
     
     __weak typeof(self) weakSelf = self;
@@ -156,7 +167,7 @@
                     [weakSelf removeActivityIndicator];
                 }
      ];
-
+    
 }
 
 


### PR DESCRIPTION
Running Instruments on an app where I'm using this category on imageViews inside cells of a collection view I noticed multiple leaks that should be solved with the proposed pull request. Basically, I added a dynamic property to keep track of the UIActivityIndicatorView that wasn't correctly released from memory (probably because of some 'timing' issue - the view wasn't deallocated in time?). With this patch Instruments doesn't show leaks anymore.
