### PR TITLE
Additions to support UIButtons

### DIFF
--- a/UIActivityIndicator-for-SDWebImage.podspec
+++ b/UIActivityIndicator-for-SDWebImage.podspec
@@ -3,10 +3,10 @@ Pod::Spec.new do |s|
   s.version       = "1.0.5"
   s.summary       = "The easiest way to add a UIActivityView to your SDWebImage view."
   s.description   = 'A category that easily allows you to use a UIActivityIndicator in SDWebImage.'
-  s.homepage      = "https://github.com/JJSaccolo/UIActivityIndicator-for-SDWebImage"
+  s.homepage      = "https://github.com/nobre84/UIActivityIndicator-for-SDWebImage"
   s.license       = { :type => 'MIT License', :file => 'LICENSE.txt' }
   s.author        = { "Giacomo Saccardo" => "gsaccardo@gmail.com" }
-  s.source        = { :git => "https://github.com/JJSaccolo/UIActivityIndicator-for-SDWebImage.git", :tag => "1.0.5" }
+  s.source        = { :git => "https://github.com/nobre84/UIActivityIndicator-for-SDWebImage.git", :tag => "1.1" }
   s.platform      = :ios, '5.0'
   s.source_files  = '*.{h,m}'
   s.requires_arc  = true

--- a/UIButton+UIActivityIndicatorForSDWebImage.h
+++ b/UIButton+UIActivityIndicatorForSDWebImage.h
@@ -1,0 +1,41 @@
+//
+//  UIButton+UIActivityIndicatorForSDWebImage.h
+//  Pods
+//
+//  Created by Rafael Nobre on 07/07/14.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import "UIButton+WebCache.h"
+#import "SDImageCache.h"
+
+@interface UIButton (UIActivityIndicatorForSDWebImage)
+
+@property (nonatomic, strong) UIActivityIndicatorView *activityIndicator;
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStye;
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStye;
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
+
+@end

--- a/UIButton+UIActivityIndicatorForSDWebImage.m
+++ b/UIButton+UIActivityIndicatorForSDWebImage.m
@@ -1,0 +1,94 @@
+//
+//  UIButton+UIActivityIndicatorForSDWebImage.m
+//  Pods
+//
+//  Created by Rafael Nobre on 07/07/14.
+//
+//
+
+#import "UIButton+UIActivityIndicatorForSDWebImage.h"
+#import "UIView+UIActivityIndicatorForSDWebImage.h"
+
+@implementation UIButton (UIActivityIndicatorForSDWebImage)
+
+@dynamic activityIndicator;
+
+#pragma mark - Methods
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
+    [self setImageWithURL:url forState:state placeholderImage:nil options:0 completed:nil usingActivityIndicatorStyle:activityStyle];
+}
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStye {
+    [self setImageWithURL:url forState:state placeholderImage:placeholder options:0 completed:nil usingActivityIndicatorStyle:activityStye];
+}
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle{
+    [self setImageWithURL:url forState:state placeholderImage:placeholder options:options completed:nil usingActivityIndicatorStyle:activityStyle];
+}
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
+    [self setImageWithURL:url forState:state placeholderImage:nil options:0 completed:completedBlock usingActivityIndicatorStyle:activityStyle];
+}
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
+    [self setImageWithURL:url forState:state placeholderImage:placeholder options:0 completed:completedBlock usingActivityIndicatorStyle:activityStyle];
+}
+
+- (void)setImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
+    
+    [self addActivityIndicatorWithStyle:activityStyle];
+    
+    __weak typeof(self) weakSelf = self;
+    [self setImageWithURL:url
+                 forState:state
+         placeholderImage:placeholder
+                  options:options
+                completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
+                    if (completedBlock) {
+                        completedBlock(image, error, cacheType);
+                    }
+                    [weakSelf removeActivityIndicator];
+                }
+     ];
+}
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
+    [self setImageWithURL:url forState:state placeholderImage:nil options:0 completed:nil usingActivityIndicatorStyle:activityStyle];
+}
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStye {
+    [self setImageWithURL:url forState:state placeholderImage:placeholder options:0 completed:nil usingActivityIndicatorStyle:activityStye];
+}
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle{
+    [self setImageWithURL:url forState:state placeholderImage:placeholder options:options completed:nil usingActivityIndicatorStyle:activityStyle];
+}
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
+    [self setImageWithURL:url forState:state placeholderImage:nil options:0 completed:completedBlock usingActivityIndicatorStyle:activityStyle];
+}
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
+    [self setImageWithURL:url forState:state placeholderImage:placeholder options:0 completed:completedBlock usingActivityIndicatorStyle:activityStyle];
+}
+
+- (void)setBackgroundImageWithURL:(NSURL *)url forState:(UIControlState)state placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle {
+    
+    [self addActivityIndicatorWithStyle:activityStyle];
+    
+    __weak typeof(self) weakSelf = self;
+    [self setBackgroundImageWithURL:url
+                           forState:state
+                   placeholderImage:placeholder
+                            options:options
+                          completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
+                              if (completedBlock) {
+                                  completedBlock(image, error, cacheType);
+                              }
+                              [weakSelf removeActivityIndicator];
+                          }
+     ];
+}
+
+@end

--- a/UIImageView+UIActivityIndicatorForSDWebImage.h
+++ b/UIImageView+UIActivityIndicatorForSDWebImage.h
@@ -22,6 +22,4 @@
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletedBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
 
-- (void)removeActivityIndicator;
-
 @end

--- a/UIImageView+UIActivityIndicatorForSDWebImage.m
+++ b/UIImageView+UIActivityIndicatorForSDWebImage.m
@@ -8,56 +8,11 @@
 
 #import "UIImageView+UIActivityIndicatorForSDWebImage.h"
 #import <objc/runtime.h>
-
-static char TAG_ACTIVITY_INDICATOR;
-
-@interface UIImageView (Private)
-
--(void)addActivityIndicatorWithStyle:(UIActivityIndicatorViewStyle) activityStyle;
-
-@end
+#import "UIView+UIActivityIndicatorForSDWebImage.h"
 
 @implementation UIImageView (UIActivityIndicatorForSDWebImage)
 
 @dynamic activityIndicator;
-
-- (UIActivityIndicatorView *)activityIndicator {
-    return (UIActivityIndicatorView *)objc_getAssociatedObject(self, &TAG_ACTIVITY_INDICATOR);
-}
-
-- (void)setActivityIndicator:(UIActivityIndicatorView *)activityIndicator {
-    objc_setAssociatedObject(self, &TAG_ACTIVITY_INDICATOR, activityIndicator, OBJC_ASSOCIATION_RETAIN);
-}
-
-- (void)addActivityIndicatorWithStyle:(UIActivityIndicatorViewStyle) activityStyle {
-    
-    if (!self.activityIndicator) {
-        self.activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:activityStyle];
-        
-        self.activityIndicator.autoresizingMask = UIViewAutoresizingNone;
-        
-        CGRect activityIndicatorBounds = self.activityIndicator.bounds;
-        float x = (self.frame.size.width - activityIndicatorBounds.size.width) / 2.0;
-        float y = (self.frame.size.height - activityIndicatorBounds.size.height) / 2.0;
-        self.activityIndicator.frame = CGRectMake(x, y, activityIndicatorBounds.size.width, activityIndicatorBounds.size.height);
-        
-        dispatch_async(dispatch_get_main_queue(), ^(void) {
-            [self addSubview:self.activityIndicator];
-        });
-    }
-    
-    dispatch_async(dispatch_get_main_queue(), ^(void) {
-        [self.activityIndicator startAnimating];
-    });
-    
-}
-
-- (void)removeActivityIndicator {
-    if (self.activityIndicator) {
-        [self.activityIndicator removeFromSuperview];
-        self.activityIndicator = nil;
-    }
-}
 
 #pragma mark - Methods
 

--- a/UIView+UIActivityIndicatorForSDWebImage.h
+++ b/UIView+UIActivityIndicatorForSDWebImage.h
@@ -1,0 +1,18 @@
+//
+//  UIView+UIActivityIndicatorForSDWebImage_h.h
+//  Pods
+//
+//  Created by Rafael Nobre on 07/07/14.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIView (UIActivityIndicatorForSDWebImage)
+
+@property (nonatomic, strong) UIActivityIndicatorView *activityIndicator;
+
+-(void)addActivityIndicatorWithStyle:(UIActivityIndicatorViewStyle) activityStyle;
+- (void)removeActivityIndicator;
+
+@end

--- a/UIView+UIActivityIndicatorForSDWebImage.m
+++ b/UIView+UIActivityIndicatorForSDWebImage.m
@@ -1,0 +1,56 @@
+//
+//  UIView+UIActivityIndicatorForSDWebImage_h.m
+//  Pods
+//
+//  Created by Rafael Nobre on 07/07/14.
+//
+//
+
+#import "UIView+UIActivityIndicatorForSDWebImage.h"
+#import <objc/runtime.h>
+
+static char TAG_ACTIVITY_INDICATOR;
+
+@implementation UIView (UIActivityIndicatorForSDWebImage)
+
+@dynamic activityIndicator;
+
+- (UIActivityIndicatorView *)activityIndicator {
+    return (UIActivityIndicatorView *)objc_getAssociatedObject(self, &TAG_ACTIVITY_INDICATOR);
+}
+
+- (void)setActivityIndicator:(UIActivityIndicatorView *)activityIndicator {
+    objc_setAssociatedObject(self, &TAG_ACTIVITY_INDICATOR, activityIndicator, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (void)addActivityIndicatorWithStyle:(UIActivityIndicatorViewStyle) activityStyle {
+    
+    if (!self.activityIndicator) {
+        self.activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:activityStyle];
+        
+        self.activityIndicator.autoresizingMask = UIViewAutoresizingNone;
+        
+        CGRect activityIndicatorBounds = self.activityIndicator.bounds;
+        float x = (self.frame.size.width - activityIndicatorBounds.size.width) / 2.0;
+        float y = (self.frame.size.height - activityIndicatorBounds.size.height) / 2.0;
+        self.activityIndicator.frame = CGRectMake(x, y, activityIndicatorBounds.size.width, activityIndicatorBounds.size.height);
+        
+        dispatch_async(dispatch_get_main_queue(), ^(void) {
+            [self addSubview:self.activityIndicator];
+        });
+    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^(void) {
+        [self.activityIndicator startAnimating];
+    });
+    
+}
+
+- (void)removeActivityIndicator {
+    if (self.activityIndicator) {
+        [self.activityIndicator removeFromSuperview];
+        self.activityIndicator = nil;
+    }
+}
+
+@end


### PR DESCRIPTION
Hi, I discovered SDWebImage and your categories today to replace AFNetworking basic loading mechanism and its awesome! I needed support for UIButtons and made a fork and private pod to support it. It may be of interest to others!
I chose to share the add/remove activity indicators implementation with a category on UIView, which makes the add method implicitly public if you import its header... I thought it would be a minor side effect in order to avoid duplicating code. Let me know what you think!
PS: This haven't been tested much, I used what was needed in my specific use case.
