### PR TITLE
Update UIImageView+UIActivityIndicatorForSDWebImage.h

### DIFF
--- a/UIImageView+UIActivityIndicatorForSDWebImage.h
+++ b/UIImageView+UIActivityIndicatorForSDWebImage.h
@@ -22,6 +22,7 @@
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options completed:(SDWebImageCompletionBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
 - (void)setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock usingActivityIndicatorStyle:(UIActivityIndicatorViewStyle)activityStyle;
 
+- (void)addActivityIndicatorWithStyle:(UIActivityIndicatorViewStyle)activityStyle;
 - (void)removeActivityIndicator;
 
 @end


### PR DESCRIPTION
Please, add this method to we make a custom use of this component in another case that we load the images only when table/scrollview decelerate, like Apple example: https://developer.apple.com/library/ios/samplecode/LazyTableImages/Introduction/Intro.html#//apple_ref/doc/uid/DTS40009394-Intro-DontLinkElementID_2
