### PR TITLE
Add support to CocoaPod for Swift project

### DIFF
--- a/UIImageView+UIActivityIndicatorForSDWebImage.h
+++ b/UIImageView+UIActivityIndicatorForSDWebImage.h
@@ -7,8 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "UIImageView+WebCache.h"
-#import "SDImageCache.h"
+#import <SDWebImage/UIImageView+WebCache.h>
+#import <SDWebImage/SDImageCache.h>
 
 @interface UIImageView (UIActivityIndicatorForSDWebImage)
 


### PR DESCRIPTION
Hi,
If i use a Swift project with cocoaPod I can import your module and the project can't be properly build.
Please see and accept changes.
