### PR TITLE
Fixed Header Search Path in CocoaPods 1.0.0

### DIFF
--- a/UIImageView+UIActivityIndicatorForSDWebImage.h
+++ b/UIImageView+UIActivityIndicatorForSDWebImage.h
@@ -7,8 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "UIImageView+WebCache.h"
-#import "SDImageCache.h"
+#import "SDWebImage/UIImageView+WebCache.h"
+#import "SDWebImage/SDImageCache.h"
 
 @interface UIImageView (UIActivityIndicatorForSDWebImage)
 


### PR DESCRIPTION
![screen shot 2016-08-12 at 3 41 17 am](https://cloud.githubusercontent.com/assets/16699097/17610486/b200dce4-603e-11e6-99d9-85b9745a40a8.png)

I saw this error when I update the CocoaPods to 1.0.0. and fixed it by  adding "SDWebImage/" to the import paths.